### PR TITLE
Make dropped packs more visible with Magenta

### DIFF
--- a/qw/s_teamplay.cfg
+++ b/qw/s_teamplay.cfg
@@ -256,10 +256,10 @@ alias _.killme.ammo         "if ($rockets < 1 AND $cells < 1) then _.do.nothing 
 
 // lost
 alias _.lost                "set_tp _.str.dropped $qt$qt; if ($health < 1 AND '$weapon' == '$tp_name_rl') then _.lost.rl else if ($health < 1 AND '$weapon' == '$tp_name_lg') then _.lost.lg else _.lost.nothing"
-alias _.lost.rl             "app_tp _.str.dropped {&cf31rl-pack&r}; wait; .tsay.lost.weapon"
-//alias _.lost.rl             "app_tp _.str.dropped {$_.mrl-pack&r}; wait; .tsay.lost.weapon"
-alias _.lost.lg             "app_tp _.str.dropped {&c29flg-pack:$cells&r}; wait; .tsay.lost.weapon"
-//alias _.lost.lg             "app_tp _.str.dropped {$_.mlg-pack:$cells&r}; wait; .tsay.lost.weapon"
+//alias _.lost.rl             "app_tp _.str.dropped {&cf31rl-pack&r}; wait; .tsay.lost.weapon"
+alias _.lost.rl             "app_tp _.str.dropped {$_.mrl-pack&r}; wait; .tsay.lost.weapon"
+//alias _.lost.lg             "app_tp _.str.dropped {&c29flg-pack:$cells&r}; wait; .tsay.lost.weapon"
+alias _.lost.lg             "app_tp _.str.dropped {$_.mlg-pack:$cells&r}; wait; .tsay.lost.weapon"
 alias _.lost.nothing        "app_tp _.str.dropped {$_.r2%E&r}; wait; .tsay.lost"
 alias _.lost.pack           "if ($health < 1 AND '$bestweapon' isin '$tp_name_rl $tp_name_lg') then _.lost else .tsay.lost.pack"
 
@@ -366,8 +366,8 @@ alias .tsay1.get.pent        "say_team $\$nick get $tp_name_pent"
 alias .tsay1.killme          "say_team $\$nick {$_.mkill me&r} $[{%l}$] $_.str.killme"
 
 alias .tsay1.lost            "say_team $\$nick {$_.rlost&r} $[{%d}$] {%E}"
-alias .tsay1.lost.weapon     "say_team $\$nick {$_.rdropped&r} $_.str.dropped $[{%d}$] {%E}"
-alias .tsay1.lost.pack       "say_team $\$nick {$_.rdropped&r} $tp_name_backpack $[{%d}$] {%E}"
+alias .tsay1.lost.weapon     "say_team $\$nick {$_.mdropped&r} $_.str.dropped $[{%d}$] {%E}"
+alias .tsay1.lost.pack       "say_team $\$nick {$_.mdropped&r} $tp_name_backpack $[{%d}$] {%E}"
 alias .tsay1.safe            "say_team $\$nick {$_.gsafe&r} $[{%l}$]"
 alias .tsay1.help            "say_team $\$nick {$_.yhelp&r} $[{%l}$]"
 alias .tsay1.replace         "say_team $\$nick replace $[{%l}$]"


### PR DESCRIPTION
1. Magenta for extra pack visibility
2. Red for lost and contextual for weapons
3. Red for lost including weapon dropped
![dropped](https://user-images.githubusercontent.com/97680337/228826052-d07b6d59-54f6-4e41-83db-5be3bcc8bc32.png)
